### PR TITLE
Update default schema name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ jaffle_shop_teradata:
       user: demo_user
       password: <PASSWORD HERE>
       logmech: TD2
-      schema: demo_user
+      schema: jaffle_shop
       tmode: ANSI
       threads: 1
       timeout_seconds: 300

--- a/macros/framework/foreign_tables.sql
+++ b/macros/framework/foreign_tables.sql
@@ -7,7 +7,7 @@
     {% do run_query('drop table '~schema_name~'.'~table_name~';') %}
 {% endif -%}
 
-{% do run_query('create foreign table '~schema_name~'.'~table_name~" using (location('"~source_path~"'));") %}
+{% do run_query('create foreign table '~schema_name~'.'~table_name~" ,EXTERNAL SECURITY gs_tables_db.PUBLIC_AUTH using (location('"~source_path~"'));") %}
 
 {% endmacro %}
 

--- a/models/consumption/dim_customers.sql
+++ b/models/consumption/dim_customers.sql
@@ -26,8 +26,8 @@ customer_orders as (
 
 customer_lifetime_value as (
     {# customer_lifetime_value is a common metric, and it is historized. #} 
-    select * from {{ ref('customer_lifetime_value') }}
-    where customer_lifetime_value.valid_period contains current_date
+    select * from {{ ref('cust_lifetime_value') }}
+    where cust_lifetime_value.valid_period contains current_date
 
 ),
 

--- a/models/consumption/schema.yml
+++ b/models/consumption/schema.yml
@@ -5,20 +5,11 @@ models:
     description: This table has basic information about a customer, as well as some derived facts based on a customer's orders
 
     columns:
-      - name: customer_id
+      - name: customer_key
         description: This is a unique identifier for a customer
         tests:
           - unique
           - not_null
-
-      - name: first_name
-        description: Customer's first name. PII.
-
-      - name: last_name
-        description: Customer's last name. PII.
-
-      - name: email
-        description: Customer's email address. PII.
 
       - name: first_order
         description: Date (UTC) of a customer's first order
@@ -29,26 +20,21 @@ models:
       - name: number_of_orders
         description: Count of the number of orders a customer has placed
 
-      - name: total_order_amount
-        description: Total value (AUD) of a customer's orders
+      - name: customer_lifetime_value
+        description: Total amount a customer has spent across all their orders
 
   - name: fct_orders
     description: This table has basic information about orders, as well as some derived facts based on payments
 
     columns:
-      - name: order_id
-        tests:
-          - unique
-          - not_null
-        description: This is a unique identifier for an order
 
-      - name: customer_id
+      - name: customer_key
         description: Foreign key to the customers table
         tests:
           - not_null
           - relationships:
               to: ref('dim_customers')
-              field: customer_id
+              field: customer_key
 
       - name: order_date
         description: Date (UTC) that the order was placed
@@ -59,32 +45,25 @@ models:
           - accepted_values:
               values: ['placed', 'shipped', 'completed', 'return_pending', 'returned']
 
-      - name: amount
-        description: Total amount (AUD) of the order
+      - name: credit_card_amount_usd
+        description: Amount of the order paid for by credit card
         tests:
           - not_null
 
-      - name: credit_card_amount
-        description: Amount of the order (AUD) paid for by credit card
+      - name: coupon_amount_usd
+        description: Amount of the order paid for by coupon
         tests:
           - not_null
 
-      - name: coupon_amount
-        description: Amount of the order (AUD) paid for by coupon
+      - name: bank_transfer_amount_usd
+        description: Amount of the order paid for by bank transfer
         tests:
           - not_null
 
-      - name: bank_transfer_amount
-        description: Amount of the order (AUD) paid for by bank transfer
+      - name: gift_card_amount_usd
+        description: Amount of the order paid for by gift card
         tests:
           - not_null
-
-      - name: gift_card_amount
-        description: Amount of the order (AUD) paid for by gift card
-        tests:
-          - not_null
-
-models:
   - name: dim_payment_method
     description: This table has basic information about a payment methods used in orders
 

--- a/models/core/cust_lifetime_value.sql
+++ b/models/core/cust_lifetime_value.sql
@@ -1,0 +1,39 @@
+{#
+Here we compute the customer historical lifetime value metric.
+The timeline of this metric is driven by the order dates (since the value increases at every order).
+If this is a full load, we build the entire timeline from the orers history.
+#}
+
+{{
+  config(
+    materialized='incremental',
+    unique_key='customer_key',
+    incremental_strategy='valid_history',
+    valid_period='valid_period'
+
+  )
+}}
+
+select
+    orders.customer_key,
+{%- if is_incremental() %}
+    --Incremental load: compute the customer value as of date
+    sum(amount_usd) as total_amount_usd,
+    period(max(order_date), ('9999-12-31' (date))) valid_period
+{%- else %}
+    --Full load: compute the historical customer value history    
+    sum(sum(amount_usd)) over(partition by orders.customer_key order by order_date ROWS UNBOUNDED PRECEDING) total_amount_usd,
+    period(
+        order_date, 
+        coalesce(lead(order_date) over(partition by orders.customer_key order by order_date) , ('9999-12-31' (date)))
+        ) valid_period
+{%- endif %}
+
+from {{ ref('lim_payments') }} payments
+left join  {{ ref('lim_orders') }} orders on payments.order_id = orders.id
+
+{% if is_incremental() %}
+group by customer_key
+{% else %}
+group by orders.customer_key, order_date
+{% endif %}

--- a/models/raw/staging/schema.yml
+++ b/models/raw/staging/schema.yml
@@ -2,53 +2,104 @@ version: 2
 
 sources:
   - name: cloud_storage
-    schema: "jaffle_shop" #This is the database in which our foreign objects reside
+    schema: "jaffle_shop" 
     tables:
       - name: raw_market_customers   
         description: "Market data from external provider"
         columns:
-          - name: Location
-            description: "Location of the source file"
+          - name: location
+            description: "Path or partition location of the source file"
           - name: id
-            description: "Anonymized customer id"
+            description: "Anonymized customer id from market provider"
           - name: spend
-            description: "Estimated customer monthly dining out spend" 
+            description: "Estimated customer monthly dining-out spend"
           - name: ptLocWkt
             description: "Customer residential area (geocoded)"     
         external:
           location: "/GS/storage.googleapis.com/clearscape_analytics_demo_data/DEMO_Market/Customer/"
           file_format: "parquet"                  
       - name: raw_market_competitors   
-        description: "Market data about competitors"
+        description: "Market competitor data (parquet files)."
+        columns:
+          - name: id
+            description: "Competitor id"
+          - name: name
+            description: "Competitor display name"
         external:
           location: "/GS/storage.googleapis.com/clearscape_analytics_demo_data/DEMO_Market/Competitor/"
           file_format: "parquet"    
 models:
   - name: stg_customers
+    description: "Staging customers table: normalized and cleaned customer attributes from raw sources."
+    meta:
+      owner: "analytics"
+      tags: ["staging", "customers"]
     columns:
       - name: customer_id
+        description: "Surrogate primary key for customers (from raw.id)"
         tests:
           - unique
           - not_null
 
+      - name: first_name
+        description: "Customer given name (cleaned)"
+      - name: last_name
+        description: "Customer family name (cleaned)"
+      - name: email
+        description: "Customer email address"
+
   - name: stg_orders
+    description: "Staging orders table: one row per order."
+    meta:
+      owner: "analytics"
+      tags: ["staging", "orders"]
     columns:
       - name: id
+        description: "Order primary key"
         tests:
           - unique
           - not_null
+
+      - name: customer_id
+        description: "FK to stg_customers.customer_id"
+        tests:
+          - not_null
+          - relationships:
+              to: ref('stg_customers')
+              field: customer_id
+
       - name: status
+        description: "Order lifecycle status"
         tests:
           - accepted_values:
               values: ['placed', 'shipped', 'completed', 'return_pending', 'returned']
+          - not_null
+
+      - name: order_date
+        description: "Date/time when the order was placed"              
 
   - name: stg_payments
+    description: "Staging payments table: payment records for orders."
+    meta:
+      owner: "analytics"
+      tags: ["staging", "payments"]
     columns:
       - name: id
+        description: "Payment primary key"
         tests:
           - unique
           - not_null
+
+      - name: order_id
+        description: "FK to stg_orders.id"
+        tests:
+          - not_null
+          - relationships:
+              to: ref('stg_orders')
+              field: id
+
       - name: payment_method
+        description: "Payment method used for the transaction"
         tests:
           - accepted_values:
               values: ['credit_card', 'coupon', 'bank_transfer', 'gift_card']

--- a/models/raw/staging/schema.yml
+++ b/models/raw/staging/schema.yml
@@ -60,7 +60,7 @@ models:
           - unique
           - not_null
 
-      - name: customer_id
+      - name: user_id
         description: "FK to stg_customers.customer_id"
         tests:
           - not_null

--- a/snapshots/dim_customers.sql
+++ b/snapshots/dim_customers.sql
@@ -3,7 +3,7 @@
 {{
     config(
       target_schema='rt186001',
-      unique_key='customer_id',
+      unique_key='customer_key',
       
       strategy='check',
       check_cols = 'all'


### PR DESCRIPTION
Changed the default schema name in the dbt connection profile as this was set to demo_user but raw_market_customers and raw_market_competitors were expecting this to be jaffle_shop.  Changing default schema here keeps things cleaner and all objects for this demo are created in the same database.